### PR TITLE
add `export` fn for  `EquivMultivariateNormal` class and tests for eq…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ $$
 P(y \mid x) = P(\rho_Y(g) y \mid \rho_X(g) x) \quad \forall g \in \mathbb{G}.
 $$
 
-Here, $x$ is a `(batch_size, dim_y + n_dof_cov)` input tensor with the first `dim_y` entries defining the mean of the distribution $\mu(x)$ and the next `n_dof_cov` entries define the free degrees of freedom from the symmetry constrained covariance matrix. See below
-
+This means that if you want to parameterize a $\mathbb{G}$-equivariant stochastic function $y = f(x)$ using neural networks, you can use any backbone architecture whose output are the input parameters of a `EquivMultivariateNormal` distribution, as shown below:
 ```python
 from escnn.group import CyclicGroup
 from escnn.nn import FieldType
@@ -90,6 +89,8 @@ e_normal = EquivMultivariateNormal(y_type, diagonal=True)
 nn = EMLP(in_type=x_type, out_type=e_normal.in_type)
 # Sample from the distribution
 x = x_type(torch.randn(10, x_type.size))
-dist = e_normal.get_distribution(nn(x)) # instance of  torch.distributions.MultivariateNormal
+z = nn(x) # (B, dim_y + n_dof_cov)
+dist = e_normal.get_distribution(z) # instance of  torch.distributions.MultivariateNormal
 y = dist.sample()  # (B, n)
 ```
+Here, $z$ is a `(batch_size, dim_y + n_dof_cov)` input tensor with the first `dim_y` entries defining the mean of the distribution $\mu(x)$ and the next `n_dof_cov` entries define the free degrees of freedom from the symmetry constrained covariance matrix. See below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "symm-learning"
-version = "0.2.1"
+version = "0.2.2"
 
 description = "Torch modules and utilities of equivariant/invariant learning"
 readme = "README.md"

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -40,7 +40,7 @@ def test_equiv_multivariate_normal(group: Group, mx: int, my: int):
     import torch
 
     from symm_learning.models.emlp import EMLP
-    from symm_learning.nn.equiv_multivariate_normal import EquivMultivariateNormal
+    from symm_learning.nn.equiv_multivariate_normal import EquivMultivariateNormal, tEquivMultivariateNormal
 
     G = group
     x_type = FieldType(escnn.gspaces.no_base_space(G), representations=[G.regular_representation] * mx)
@@ -52,3 +52,7 @@ def test_equiv_multivariate_normal(group: Group, mx: int, my: int):
     e_normal = EquivMultivariateNormal(y_type, diagonal=True)
 
     e_normal.check_equivariance(atol=1e-6, rtol=1e-6)
+
+    # Test that the exported torch module is also equivariant
+    torch_e_normal: tEquivMultivariateNormal = e_normal.export()
+    torch_e_normal.check_equivariance(in_type=e_normal.in_type, y_type=y_type, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
This pull request introduces enhancements to the `EquivMultivariateNormal` module, including new functionality for exporting it to a standard PyTorch module, clarifications in the documentation, and updates to the testing suite. Additionally, the project version has been incremented to reflect these changes. Below is a summary of the most important changes:

### Enhancements to `EquivMultivariateNormal` functionality:
- Introduced a new `export` method in `EquivMultivariateNormal` to convert it from a `EquivariantModule` to a `torch.nn.Module` (`tEquivMultivariateNormal`) for inference and compatibility with other packages assuming torch modules.

### Updates to `EquivMultivariateNormal` behavior:
- Introduced a new attribute `n_cov_params` to track the number of covariance parameters. This will be used for non-diagonal parametrizations which will come soon...

### Documentation and examples:
- Updated the `README.md` to clarify the usage of the `EquivMultivariateNormal` distribution and its input tensor structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R96)

### Testing improvements:
- Updated the test suite to include tests for the exported `tEquivMultivariateNormal` module, ensuring its equivariance properties match the original module. [[1]](diffhunk://#diff-e449b2c5758c5d63d7ea8ff8f7d918dd4071ab45bd82d843fc34b522b4d143aeL43-R43) [[2]](diffhunk://#diff-e449b2c5758c5d63d7ea8ff8f7d918dd4071ab45bd82d843fc34b522b4d143aeR55-R58)

### Project metadata:
- Incremented the project version from `0.2.1` to `0.2.2` in `pyproject.toml` to reflect the new features and updates.