### PR TITLE
Add export to modules and cache for efficiency of stats.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "symm-learning"
-version = "0.2.3"
+version = "0.2.4"
 
 description = "Torch modules and utilities of equivariant/invariant learning"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "symm-learning"
-version = "0.2.2"
+version = "0.2.3"
 
 description = "Torch modules and utilities of equivariant/invariant learning"
 readme = "README.md"

--- a/symm_learning/nn/__init__.py
+++ b/symm_learning/nn/__init__.py
@@ -1,0 +1,10 @@
+from .disentangled import Change2DisentangledBasis  # noqa: D104
+from .equiv_multivariate_normal import EquivMultivariateNormal, tEquivMultivariateNormal
+from .irrep_pooling import IrrepSubspaceNormPooling
+
+__all__ = [
+    "Change2DisentangledBasis",
+    "EquivMultivariateNormal",
+    "tEquivMultivariateNormal",
+    "IrrepSubspaceNormPooling",
+]

--- a/symm_learning/nn/irrep_pooling.py
+++ b/symm_learning/nn/irrep_pooling.py
@@ -25,6 +25,11 @@ class IrrepSubspaceNormPooling(EquivariantModule):
         self.out_type = FieldType(
             gspace=in_type.gspace, representations=[self.G.trivial_representation] * n_inv_features
         )
+        # Store isotypic subspaces start/end indices for efficient slicing
+        self.register_buffer("iso_start_dims", torch.tensor(self.in2iso.out_type.fields_start, dtype=torch.int64))
+        self.register_buffer("iso_end_dims", torch.tensor(self.in2iso.out_type.fields_end, dtype=torch.int64))
+        irreps_ids = [rep.irreps[0] for rep in self.in2iso.out_type.representations]
+        self.register_buffer("irreps_dims", torch.tensor([self.G.irrep(*irreps_id).size for irreps_id in irreps_ids]))
 
     def forward(self, x: GeometricTensor) -> GeometricTensor:
         """Computes the norm of each G-irreducible subspace of the input GeometricTensor.
@@ -39,11 +44,12 @@ class IrrepSubspaceNormPooling(EquivariantModule):
             GeometricTensor: G-Invariant tensor of shape (..., N) where N is the number of irreps in the input type.
         """
         x_ = self.in2iso(x)
-        x_iso = self._orth_proj_isotypic_subspaces(x_)
+        # Decompose the input tensor into isotypic subspaces
+        x_iso = [x_.tensor[..., s:e] for s, e in zip(self.iso_start_dims, self.iso_end_dims)]
 
         inv_features_iso = []
-        for x_k, rep_k in zip(x_iso, self.in_type_iso.representations):
-            n_irrep_G_stable_spaces = len(rep_k.irreps)  # Number of G-invariant features = multiplicity of irrep
+        for x_k, s, e, irrep_dim in zip(x_iso, self.iso_start_dims, self.iso_end_dims, self.irreps_dims):
+            n_irrep_G_stable_spaces = int((e - s) / irrep_dim)  # Number of G-invariant features = multiplicity of irrep
             # This basis is useful because we can apply the norm in a vectorized way
             # Reshape features to [batch, n_irrep_G_stable_spaces, num_features_per_G_stable_space]
             x_field_p = torch.reshape(x_k, (x_k.shape[0], n_irrep_G_stable_spaces, -1))
@@ -58,14 +64,53 @@ class IrrepSubspaceNormPooling(EquivariantModule):
         )
         return self.out_type(inv_features)
 
-    def _orth_proj_isotypic_subspaces(self, z: GeometricTensor) -> [torch.Tensor]:
-        """Compute the orthogonal projection of the input tensor into the isotypic subspaces."""
-        assert z.type == self.in_type_iso, f"Expected input tensor of type {self.in_type_iso}, got {z.type}"
-        z_iso = [z.tensor[..., s:e] for s, e in zip(z.type.fields_start, z.type.fields_end)]
-        return z_iso
-
     def evaluate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:  # noqa: D102
         return input_shape[:-1] + (len(self.out_type.size),)
 
     def extra_repr(self) -> str:  # noqa: D102
         return f"{self.G}-Irrep Norm Pooling: in={self.in_type} -> out={self.out_type}"
+
+    def export(self) -> torch.nn.Module:
+        """Exports the module to a standard PyTorch module."""
+        return tIrrepSubspaceNormPooling(
+            in2iso=self.in2iso.export(),
+            iso_start_dims=self.iso_start_dims,
+            iso_end_dims=self.iso_end_dims,
+            irreps_dims=self.irreps_dims,
+        )
+
+
+class tIrrepSubspaceNormPooling(torch.nn.Module):
+    """Torch module result of exporting the IrrepSubspaceNormPooling layer to a standard PyTorch module."""
+
+    def __init__(
+        self,
+        in2iso: torch.nn.Module,
+        iso_start_dims: torch.Tensor,
+        iso_end_dims: torch.Tensor,
+        irreps_dims: torch.Tensor,
+    ):
+        super(tIrrepSubspaceNormPooling, self).__init__()
+        self.in2iso = in2iso
+        self.iso_start_dims = iso_start_dims
+        self.iso_end_dims = iso_end_dims
+        self.irreps_dims = irreps_dims
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Computes the norm of each G-irreducible subspace of the input tensor."""
+        x_ = self.in2iso(x)
+        # Decompose the input tensor into isotypic subspaces
+        x_iso = [x_[..., s:e] for s, e in zip(self.iso_start_dims, self.iso_end_dims)]
+
+        inv_features_iso = []
+        for x_k, s, e, irrep_dim in zip(x_iso, self.iso_start_dims, self.iso_end_dims, self.irreps_dims):
+            n_irrep_G_stable_spaces = int((e - s) / irrep_dim)  # Number of G-invariant features = multiplicity of irrep
+            # This basis is useful because we can apply the norm in a vectorized way
+            # Reshape features to [batch, n_irrep_G_stable_spaces, num_features_per_G_stable_space]
+            x_field_p = torch.reshape(x_k, (x_k.shape[0], n_irrep_G_stable_spaces, -1))
+            # Compute G-invariant measures as the norm of the features in each G-stable space
+            inv_field_features = torch.norm(x_field_p, dim=-1)
+            # Append to the list of inv features
+            inv_features_iso.append(inv_field_features)
+        inv_features = torch.cat(inv_features_iso, dim=-1)
+        return inv_features

--- a/symm_learning/nn/irrep_pooling.py
+++ b/symm_learning/nn/irrep_pooling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import torch
 from escnn.nn import EquivariantModule, FieldType, GeometricTensor
 
-from symm_learning.nn.disentangled import Change2DisentangledBasis
+from symm_learning.nn import Change2DisentangledBasis
 
 
 class IrrepSubspaceNormPooling(EquivariantModule):


### PR DESCRIPTION
This pull request introduces several updates to the `symm-learning` library, including new functionality, performance optimizations, and test coverage improvements. The changes primarily focus on enhancing the `Change2DisentangledBasis` and `IrrepSubspaceNormPooling` modules, caching tensors for efficiency, and adding export functionality for compatibility with standard PyTorch modules.

### Enhancements to `Change2DisentangledBasis` and `IrrepSubspaceNormPooling`:

* Added an `export` method to both `Change2DisentangledBasis` and `IrrepSubspaceNormPooling` to convert them into standard PyTorch modules, enabling broader compatibility and usability. (`symm_learning/nn/disentangled.py` - [[1]](diffhunk://#diff-1027f29a5ee09bd0127a35d522f74ccc4bb00d1c488362fb81b5ed36711cf6d0R53-R66) `symm_learning/nn/irrep_pooling.py` - [[2]](diffhunk://#diff-f1146a7e4bf58cb48baec0da417ea7415ef2a08577401e530cdd3a64a0a9d699L61-R116)
* Introduced the `tIrrepSubspaceNormPooling` class, which implements the exported functionality of `IrrepSubspaceNormPooling` in pure PyTorch. (`symm_learning/nn/irrep_pooling.py` - [symm_learning/nn/irrep_pooling.pyL61-R116](diffhunk://#diff-f1146a7e4bf58cb48baec0da417ea7415ef2a08577401e530cdd3a64a0a9d699L61-R116))

### Performance optimizations:

* Added caching for invariant orthogonal projectors and change-of-basis tensors in the `var_mean` function to avoid redundant computations. (`symm_learning/stats.py` - [[1]](diffhunk://#diff-ffd46b6235a2c1035b46d1b21ad442d9a6f0d026c841c6705e1c0fcd2b1ab424R36-R60) [[2]](diffhunk://#diff-ffd46b6235a2c1035b46d1b21ad442d9a6f0d026c841c6705e1c0fcd2b1ab424L56-R70)
* Replaced direct tensor assignments with `register_buffer` for storing non-trainable tensors like `Qin2iso` and isotypic subspace indices, improving model serialization and device handling. (`symm_learning/nn/disentangled.py` - [[1]](diffhunk://#diff-1027f29a5ee09bd0127a35d522f74ccc4bb00d1c488362fb81b5ed36711cf6d0L31-R32) `symm_learning/nn/irrep_pooling.py` - [[2]](diffhunk://#diff-f1146a7e4bf58cb48baec0da417ea7415ef2a08577401e530cdd3a64a0a9d699R28-R32)

### Test coverage improvements:

* Added new tests to validate the equivariance and export functionality of `Change2DisentangledBasis` and `IrrepSubspaceNormPooling`. These tests ensure consistency between the original and exported modules. (`test/test_modules.py` - [[1]](diffhunk://#diff-e449b2c5758c5d63d7ea8ff8f7d918dd4071ab45bd82d843fc34b522b4d143aeL20-R74) [[2]](diffhunk://#diff-e449b2c5758c5d63d7ea8ff8f7d918dd4071ab45bd82d843fc34b522b4d143aeL43-R91)

### Other changes:

* Updated imports in `__init__.py` to include new modules and ensure proper exposure of new functionality. (`symm_learning/nn/__init__.py` - [symm_learning/nn/__init__.pyR1-R10](diffhunk://#diff-b5db5455fef67fd996ccca468a4dedc63dbb5605d2a275ad9616ac64f3525467R1-R10))
* Incremented the project version from `0.2.2` to `0.2.4` in `pyproject.toml`. (`pyproject.toml` - [pyproject.tomlL7-R7](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7))